### PR TITLE
Add Inference-Time Hyper-Scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ This repository is for our paper:
 #### Efficient TTS
 | Title & Authors | Introduction | Links |
 |:--|  :----: | :---:|
+|[Inference-Time Hyper-Scaling with KV Cache Compression](https://arxiv.org/abs/2506.05345) <br> Adrian Łańcucki, Konrad Staniszewski, Piotr Nawrot, Edoardo M. Ponti |<img width="1002" alt="image" src="https://arxiv.org/html/2506.05345v1/x2.png"> |[Paper](https://arxiv.org/abs/2506.05345)| [//]:
 |[Control-R: Towards controllable test-time scaling](https://arxiv.org/abs/2506.00189) <br> Di Zhang, Weida Wang, Junxian Li, Xunzhi Wang, Jiatong Li, Jianbo Wu, Jingdi Lei, Haonan He, Peng Ye, Shufei Zhang, Wanli Ouyang, Yuqiang Li, Dongzhan Zhou |<img width="1002" alt="image" src="https://arxiv.org/html/2506.00189v1/x1.png"> |[Paper](https://arxiv.org/abs/2506.00189)| [//]: #06/13
 |[Plan and Budget: Effective and Efficient Test-Time Scaling on Large Language Model Reasoning](https://arxiv.org/abs/2505.16122) <br> Junhong Lin, Xinyue Zeng, Jie Zhu, Song Wang, Julian Shun, Jun Wu, Dawei Zhou |<img width="1002" alt="image" src="figures/bbam.png"> |[Paper](https://arxiv.org/abs/2505.16122)| [//]: #06/13
 |[First Finish Search: Efficient Test-Time Scaling in Large Language Models](https://arxiv.org/abs/2505.18149) <br> Aradhye Agarwal, Ayan Sengupta, Tanmoy Chakraborty |<img width="1002" alt="image" src="figures/FFS.png"> |[Paper](https://arxiv.org/abs/2505.18149)| [//]: #06/13


### PR DESCRIPTION
Thank You for Your amazing work!

NVIDIA recently released a paper on test time scaling, demonstrating that LLM reasoning can be boosted within a given memory/time budget by applying KV-cache eviction/compression methods. They also propose Dynamic Memory Sparsification (DMS), which improves upon Dynamic Memory Compression (DMC) while using significantly less training time.

Paper: Inference-Time Hyper-Scaling with KV Cache Compression
arxiv: https://arxiv.org/abs/2506.05345